### PR TITLE
Add SASS definition extraction for Blackwell, Ada Lovelace and other architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NVCC=/usr/local/cuda/bin/nvcc
 NVDISASM=/usr/local/cuda/bin/nvdisasm
 PYTHON=python3
 
-architectures=sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_120 sm_121
+architectures=sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_120
 
 targets = $(architectures:=_instructions.txt) $(architectures:=_latencies.txt)
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NVCC=/usr/local/cuda/bin/nvcc
 NVDISASM=/usr/local/cuda/bin/nvdisasm
 PYTHON=python3
 
-architectures=sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_103 sm_103a sm_120 sm_121
+architectures=sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_103 sm_103a sm_120 sm_121
 
 targets = $(architectures:=_instructions.txt) $(architectures:=_latencies.txt)
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NVCC=/usr/local/cuda/bin/nvcc
 NVDISASM=/usr/local/cuda/bin/nvdisasm
 PYTHON=python3
 
-architectures=sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_90
+architectures=sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_103 sm_103a sm_120 sm_121
 
 targets = $(architectures:=_instructions.txt) $(architectures:=_latencies.txt)
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NVCC=/usr/local/cuda/bin/nvcc
 NVDISASM=/usr/local/cuda/bin/nvdisasm
 PYTHON=python3
 
-architectures=sm_35 sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_103 sm_103a sm_120 sm_121
+architectures=sm_37 sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_103 sm_103a sm_120 sm_121
 
 targets = $(architectures:=_instructions.txt) $(architectures:=_latencies.txt)
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NVCC=/usr/local/cuda/bin/nvcc
 NVDISASM=/usr/local/cuda/bin/nvdisasm
 PYTHON=python3
 
-architectures=sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_103 sm_103a sm_120 sm_121
+architectures=sm_50 sm_52 sm_53 sm_60 sm_61 sm_62 sm_70 sm_72 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_90a sm_100 sm_100a sm_120 sm_121
 
 targets = $(architectures:=_instructions.txt) $(architectures:=_latencies.txt)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For some additional, unrelated observations, see [OTHER](OTHER.md).
 ## How to run
 The easy way is by simply running [this notebook](https://colab.research.google.com/drive/1qjdpjCgozg-yKfW_u9lJfHuxOu0NrnGG) in Google Colab. No requirements.
 
-Requirements to run locally: Linux, Python 3, CUDA Toolkit. Run `make` to generate the raw files describing instructions and latencies. Be sure to change the paths in the beginning of the Makefile if they are different on your system. Tested with CUDA 11.6.
+Requirements to run locally: Linux, Python 3, CUDA Toolkit. Run `make` to generate the raw files describing instructions and latencies. Be sure to change the paths in the beginning of the Makefile if they are different on your system. Tested on CUDA 11.6 by maintainer and CUDA 12.8 by [1 contributor](https://github.com/OPS-NeoRetro).
 
 ## How it works
 1. `nvcc` is used to compile example.cu to .cubin binaries for a list of architectures.


### PR DESCRIPTION
Hey @0xD0GF00D, I tested your contraption with a Google Colab NVIDIA T4 runtime, and so far, I managed to snag CUDA 12.8 Toolkit and got Blackwell code. I remade the Makefile for this exact purpose. I managed to get this ZIP file from a modified Google Colab run: [SASSDefs_fixed.zip](https://github.com/user-attachments/files/31075069/SASSDefs_fixed.zip)

If you have the time, please review and merge this ASAP. This is the first PR of this repo. I now got valuable information about NVIDIA GPU internals from your contraption.